### PR TITLE
feat: CloudWatch Metrics Support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,6 +151,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sdk-cloudwatch"
+version = "1.93.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346ccfc8adf39ee6d474dba12dda6fcac56a88087acfd6a5be5ccff7bb46e86b"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-compression",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "fastrand",
+ "flate2",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
 name = "aws-sdk-cloudwatchlogs"
 version = "1.104.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,6 +320,23 @@ dependencies = [
  "futures-util",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "aws-smithy-compression"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ceb9b25cf3a8b10ae5c3cf6490488c092871b120a01256af387c51c2eeace313"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "flate2",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "pin-project-lite",
+ "tracing",
 ]
 
 [[package]]
@@ -837,6 +880,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "aws-config",
+ "aws-sdk-cloudwatch",
  "aws-sdk-cloudwatchlogs",
  "aws-sdk-ecs",
  "chrono",
@@ -884,6 +928,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0399f9d26e5191ce32c498bebd31e7a3ceabc2745f0ac54af3f335126c3f24b3"
 
 [[package]]
+name = "flate2"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -926,6 +980,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -944,9 +1009,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-task",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ tokio = { version = "1", features = ["full"] }
 aws-config = { version = "1.1", features = ["behavior-version-latest"] }
 aws-sdk-ecs = "1.53"
 aws-sdk-cloudwatchlogs = "1.51"
+aws-sdk-cloudwatch = "1.51"
 anyhow = "1.0"
 chrono = "0.4"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -358,6 +358,9 @@ mod tests {
         assert_eq!(config.behavior.refresh_interval, 30);
         assert_eq!(config.behavior.default_view, "clusters");
         assert_eq!(config.ui.theme, "dark");
+        assert_eq!(config.metrics.enabled, true);
+        assert_eq!(config.metrics.time_range_minutes, 60);
+        assert_eq!(config.metrics.refresh_interval, 60);
         assert!(config.aws.region.is_none());
         assert!(config.aws.profile.is_none());
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -198,6 +198,7 @@ async fn run_app<B: ratatui::backend::Backend>(
                             KeyCode::Char('r') => app.refresh().await?,
                             KeyCode::Char('d') => app.describe().await?,
                             KeyCode::Char('l') => app.view_logs().await?,
+                            KeyCode::Char('m') => app.view_metrics().await?,
                             KeyCode::Char('t') => app.toggle_auto_tail(),
                             KeyCode::Char('x') => app.execute_action().await?,
                             _ => {}


### PR DESCRIPTION
## Summary
Implements CloudWatch metrics viewing for ECS services, allowing users to monitor CPU and Memory utilization directly from the TUI.

## Features Added

### CloudWatch Integration
- Integrated AWS CloudWatch GetMetricStatistics API
- Fetches CPU and Memory utilization metrics for ECS services
- Uses 5-minute data periods for granular insights
- Configurable time range (default: 60 minutes)

### Data Structures
- `MetricDatapoint` - Represents individual CloudWatch metric data points (timestamp, average, maximum, minimum, sum, sample count)
- `Metrics` - Container for CPU and memory datapoint collections
- Extended `EcsClient` with CloudWatch client and `get_service_metrics()` method

### Application State
- Added `AppState::Metrics` variant for metrics view
- Added `metrics: Option<Metrics>` field to store fetched metrics
- Navigation: Services → Metrics (press 'm')
- Back navigation: Metrics → Services (press 'Esc' or 'h')
- Refresh support: Press 'r' in Metrics view to reload data

### UI Display
- Simple, readable text-based metrics presentation
- **CPU Utilization**: Average, Maximum, Data point count
- **Memory Utilization**: Average, Maximum, Data point count
- Color coding: Green (averages), Yellow (maximums), Cyan (headers)
- Shows time range in title bar
- Helpful error messages when metrics unavailable

### Configuration
Added `[metrics]` section to config with:
```toml
[metrics]
enabled = true
time_range_minutes = 60
refresh_interval = 60
```

## Keybindings (Services View)
- `m` - View metrics for selected service

## Keybindings (Metrics View)
- `r` - Refresh metrics data
- `Esc` / `h` - Return to Services view

## UI Updates
- Updated help screen with new 'm' keybinding
- Metrics count shown in footer
- Service name shown in Metrics view header

## Technical Details
- Uses AWS/ECS namespace with ServiceName and ClusterName dimensions
- Fetches Average and Maximum statistics
- Parallel API calls for CPU and Memory metrics
- Proper error handling and user feedback
- Time calculations using SystemTime and UNIX_EPOCH

## Test Plan
- [x] Build completes without errors (84 tests pass)
- [x] Unit tests pass for config defaults
- [ ] Manual testing: View metrics from Services view
- [ ] Manual testing: Refresh metrics in Metrics view
- [ ] Manual testing: Navigate back to Services view
- [ ] Manual testing: Verify metrics display with real AWS data

## Dependencies
- Added `aws-sdk-cloudwatch = "1.51"` to Cargo.toml

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>